### PR TITLE
Remove reference to non-standard MIME types

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ and choose **Open with... ▶ dot**.
 The following [DOT language](https://www.graphviz.org/doc/info/lang.html) file
 extensions are supported with live preview and syntax highlighting:
 - `.gv`
-- `.neato`
 - `.dot`
+- `.neato`
 
 ## Inline rendering
 The following MIME types can also be rendered inline in Notebooks and Consoles:
-- `application/vnd.graphviz.neato`
-- `application/vnd.graphviz`
+- `text/vnd.graphviz.neato`
+- `text/vnd.graphviz`
 
 > Check out some MIME examples in the
 [Cookbook](./samples/Graphviz Rich Display Cookbook.ipynb).

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ extensions are supported with live preview and syntax highlighting:
 - `.neato`
 
 ## Inline rendering
-The following MIME types can also be rendered inline in Notebooks and Consoles:
-- `text/vnd.graphviz.neato`
+The following MIME type can also be rendered inline in Notebooks and Consoles:
 - `text/vnd.graphviz`
 
 > Check out some MIME examples in the

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   "scripts": {
     "build": "tsc --project src",
     "clean": "rimraf lib",
-    "lint": "tslint --project src --fix && prettier --write \"{src,style,typings}/**/*.{ts,css,json}\""
+    "lint": "tslint --project src --fix && prettier --write \"{src,style,typings}/**/*.{ts,css,json}\"",
+    "watch": "jlpm build --watch"
   },
   "version": "0.2.1"
 }

--- a/samples/Graphviz Rich Display Cookbook.ipynb
+++ b/samples/Graphviz Rich Display Cookbook.ipynb
@@ -18,14 +18,14 @@
    "source": [
     "from IPython.display import display, update_display\n",
     "\n",
-    "def display_graphviz(dot, mimetype=\"application/vnd.graphviz\", **kwargs):\n",
+    "def display_graphviz(dot, mimetype=\"text/vnd.graphviz\", **kwargs):\n",
     "    \"\"\" Send some DOT to the frontend\n",
     "    \n",
     "    Get a handle to update later by calling `display_graphviz` with `display_id=True` \n",
     "    \"\"\"\n",
     "    return display({mimetype: dot}, raw=True, **kwargs)\n",
     "\n",
-    "def update_graphviz(dot, handle, mimetype=\"application/vnd.graphviz\", **kwargs):\n",
+    "def update_graphviz(dot, handle, mimetype=\"text/vnd.graphviz\", **kwargs):\n",
     "    \"\"\" Update an already-displayed DOT\n",
     "    \"\"\"\n",
     "    update_display({mimetype: dot}, display_id=handle.display_id, raw=True, **kwargs)"

--- a/samples/how_it_works.dot
+++ b/samples/how_it_works.dot
@@ -20,7 +20,7 @@ subgraph cluster_mine { label="my computer"
     -> {node_modules[shape=rect label="node_modules\n~176MB"]}
     -> webpack
     -> {
-      lab_bundle[label=" lab.bundle.js \n~6MB" shape=rect]
+      lab_bundle[label=" lab.bundle.js \n~2MB" shape=rect]
       viz_bundle[label=" viz.bundle.js \n~2MB" shape=rect]
     }
   }
@@ -33,7 +33,7 @@ subgraph cluster_mine { label="my computer"
     dot[label="graph.dot" shape=rect]
     ipynb[label="notebook.ipynb" shape=rect]
   }
-  
+
   subgraph cluster_server {label="my notebook server"
     ContentsManager
     KernelManager
@@ -47,7 +47,7 @@ subgraph cluster_mine { label="my computer"
     CodeMirror
     RenderedData
     model[label="IMimeModel"]
-    mime[label="application/vnd.graphviz" shape=rect]
+    mime[label="text/vnd.graphviz" shape=rect]
     Viz
     raw[label="Raw SVG" shape=rect]
     svg[label="Interactive\nSVG" shape=rect]
@@ -59,7 +59,7 @@ me -> {CodeMirror svg}[dir=both]
 lab_bundle -> Application -> DocRegistry
 DocRegistry -> {Notebook FileEditor}[dir=both]
 viz_bundle -> Viz[style=dashed]
-{ipynb dot} -> ContentsManager[dir=both] 
+{ipynb dot} -> ContentsManager[dir=both]
 ContentsManager -> DocRegistry[dir=both]
 Notebook -> kernel -> mime -> model
 {Notebook FileEditor} -> CodeMirror

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,15 +2,10 @@
 export const TYPES: {
   [key: string]: {name: string; extensions: string[]; engine: any};
 } = {
-  'application/vnd.graphviz': {
+  'text/vnd.graphviz': {
     name: 'dot',
-    extensions: ['.gv', '.dot'],
+    extensions: ['.gv', '.dot', '.neato'],
     engine: 'dot',
-  },
-  'application/vnd.graphviz.neato': {
-    name: 'neato',
-    extensions: ['.neato'],
-    engine: 'neato',
   },
 };
 


### PR DESCRIPTION
Graphviz came up over on https://github.com/nteract/nteract/pull/1801, as they are now ready to start doing async importing and so the crushing weight of viz.js is no longer (as big of) an issue.

Even though the code shouts out the official [IANA page](https://www.iana.org/assignments/media-types/text/vnd.graphviz) for the MIME type, it was set to something other than that value! Looking around, I couldn't even find a reference to the `neato` subtype, but could find a vanishingly small number of `.neato` files up on github, so it seems like keeping the extension is not entirely crazy.

Anyhow, this PR propose only answering the official MIME type.

I also snuck in a tiny fix to `how_it_works.dot`: I was over-reporting the size of the jupyterlab bundle based on a dev build (6MB) vs the production build (2MB).